### PR TITLE
Remove AWS CLI installation from edge Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG APP_ROOT
 ARG POETRY_HOME
 ARG POETRY_VERSION
 
-# System deps, Azure CLI (signed keyring), Poetry, kubectl, AWS CLI v2
+# System deps, Azure CLI (signed keyring), Poetry, kubectl
 RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -47,13 +47,6 @@ RUN set -eux; \
     # kubectl (latest stable)
     curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
     chmod 0755 /usr/local/bin/kubectl; \
-    \
-    # AWS CLI v2
-    cd /tmp; \
-    curl -fsSLo awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"; \
-    unzip -q awscliv2.zip; \
-    ./aws/install --update; \
-    rm -rf aws awscliv2.zip; \
     \
     # Clean
     apt-get clean; \


### PR DESCRIPTION
## Summary
- remove the AWS CLI installation step and related comment from the production Dockerfile
- verified remaining layers and entrypoint do not reference the removed aws binary

## Testing
- docker build -t intellioptics-edge-test . *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db34a825f48326a859c44228ff58b5